### PR TITLE
Change breast size calculation to more accurately reflect breast volume

### DIFF
--- a/body_tags.py
+++ b/body_tags.py
@@ -121,14 +121,14 @@ class HeightType(StashTagEnumComparable):
     SHORT   = StashTagDC("Short",  threshold=(operator.le, 160))
     TALL    = StashTagDC("Tall",   threshold=(operator.ge, 180))
 
-# threshold based off of performer.bust
+# threshold based off of performer.breast_volume
 class BreastSize(StashTagEnumComparable):
-    TINY    = StashTagDC("Tiny Breasts",   threshold=(operator.lt, 27))
-    SMALL   = StashTagDC("Small Breasts",  threshold=(operator.lt, 32))
-    MEDIUM  = StashTagDC("Medium Breasts", threshold=(operator.lt, 37))
-    LARGE   = StashTagDC("Large Breasts",  threshold=(operator.lt, 42))
-    HUGE    = StashTagDC("Huge Breasts",   threshold=(operator.lt, 47))
-    MASSIVE = StashTagDC("Massive Breasts",threshold=(operator.ge, 47))
+    TINY    = StashTagDC("Tiny Breasts",   threshold=(operator.lt, 16))
+    SMALL   = StashTagDC("Small Breasts",  threshold=(operator.lt, 19))
+    MEDIUM  = StashTagDC("Medium Breasts", threshold=(operator.lt, 23))
+    LARGE   = StashTagDC("Large Breasts",  threshold=(operator.lt, 27))
+    HUGE    = StashTagDC("Huge Breasts",   threshold=(operator.lt, 31))
+    MASSIVE = StashTagDC("Massive Breasts",threshold=(operator.ge, 31))
 
 # threshold based off of performer.hips 
 class ButtSize(StashTagEnumComparable):

--- a/performer_body_calculator.py
+++ b/performer_body_calculator.py
@@ -92,11 +92,12 @@ class StashPerformer:
 
         self.__dict__.update(resp)
 
-        self.cupsize = ""
-        self.band    = 0.0
-        self.waist   = 0.0
-        self.hips    = 0.0
-        self.bust    = None
+        self.cupsize       = ""
+        self.band          = 0.0
+        self.waist         = 0.0
+        self.hips          = 0.0
+        self.bust          = None
+        self.breast_volume = None
         
         self.bmi = 0
         self.body_shapes = []
@@ -148,7 +149,9 @@ class StashPerformer:
         for bust_diff, cup_list in enumerate(body_tags.BUST_DIFF_IDX):
             if self.cupsize in cup_list:
                 self.bust = self.band + bust_diff
-        if not self.bust:
+                self.breast_volume = (self.band / 2.0) + bust_diff
+                log.debug(f"Bra size {int(self.band)}{self.cupsize} converted to {(self.band / 2.0)} + {bust_diff} = {self.breast_volume} volume points")
+        if not self.breast_volume:
             raise Exception(f"could not identify cupsize '{self.cupsize}' add to 'BUST_DIFF_IDX' list")
 
     def calculate_bmi(self):
@@ -176,9 +179,9 @@ class StashPerformer:
     def set_breast_size(self):
         self.bust_band_diff = None
         self.breast_size = None
-        if not self.cupsize or not self.bust:
+        if not self.cupsize or not self.breast_volume:
             return
-        self.breast_size = BreastSize.match_threshold(self.bust)
+        self.breast_size = BreastSize.match_threshold(self.breast_volume)
 
     def set_butt_size(self):
         self.butt_size = None


### PR DESCRIPTION
# Summary
This changes the calculation of breast size to be based on breast volume. The new calculation uses the concept of "sister sizes" to ensure that sizes are categorized fairly across different band and cup sizes.

# Reasoning
Two sizes are "sisters" and have approximately the same cup volume if the following formula gives the same result (when using US measurements): `(band_inches / 2) + cupsize_inches`
See: https://bustyresources.fandom.com/wiki/Sister_size and https://sizeschart.com/blog/what-is-bra-sister-sizes

For example, the two sizes below are sisters:
30J `15 + 10 = 25`
42D `21 + 4 = 25`

The old calculation (`band_inches + cupsize_inches`) was similar, but because sister sizes require 2 inches of increased band for every 1 cupsize, the old calculation heavily favored performers with large band sizes. Using the two sizes above as an example, the old calculation would have awarded 40 points (Large) to 30J, but 46 points (Huge) to 42D, even though they both have the same breast volume.

If you'd like some visual confirmation that volume should be the determining factor in categorizing breast sizes, and that sister sizes have the same volume, I recommend comparing pictures of performers with sister sizes (such as 30J and 42D) and seeing how they are much closer in volume (and visual impact / perceived size) than two sizes that scored the same using the old calculation (such as 42D and 32N). In my opinion at least, 32N is much bigger than 42D and they should be in completely different categories.

# Visualization
This chart (taken from [here](https://bustyresources.fandom.com/wiki/Sister_size#US_sister_sizes)) shows sister sizes, **where all sizes on the same row have equal volume**. For example, if we look at the 4th row, we can see that 28C, 30B, 32A, and 34AA are all sisters and thus have the same volume.
![image](https://github.com/stg-annon/performerBodyCalculator/assets/149206247/534481a4-da7d-40cc-8797-802dc68043ca)

## Old Calculation
With the old calculation method, the categories looked like this:
![image](https://github.com/stg-annon/performerBodyCalculator/assets/149206247/3fa22b29-dc70-46dc-b74e-cd01d962a353)
Here we can see that the rows of sister sizes are broken up between different categories (for example, 30J and 42D). Similarly, 42D and 32N are in the same category, despite having very different volume.

## New Calculation
With the new calculation method (after adjusting the category thresholds), the categories look like this:
![image](https://github.com/stg-annon/performerBodyCalculator/assets/149206247/7a9b8681-2719-43d7-84ce-c3318edab410)
Here we can see that all groups of sister sizes each have only one category. Our example sister sizes (30J and 42D) are now both given 25 points and fall in the same category. Also, our example of differing sizes (42D and 32N) are now in the Large and Massive categories, respectively.

# Results
After making the change, the breast sizes of the performers in my library appeared significantly more uniform, and I no longer had "huh?" moments when checking a performer's size tag. That said, please try this out for yourself! I'm happy with the categories thresholds, but feel free to modify them as you see fit.

# Notes
Please be aware that the "volume points" used in the new calculation do not directly translate to any unit of measurement (as far as I know).