### PR TITLE
Add Support for Different Measurement Formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,14 @@
 # Stash Plugin: Performer Body Calculator 
 
-This plugin will tag performers based on existing metadata within stash the `measurements` attribute must be present for a performer to be tagged, additionally the `height` and `weight` attributes will be used if present but are not required
+This plugin will tag performers based on existing metadata within Stash.
+
+If the `Measurements` attribute is present, it will be used to calculate the performer's body part sizes and body shape. The following formats are supported:
+- `32D-28-34` (Bra Size, Waist, Hips)
+- `36-28-34` (Bust, Waist, Hips)
+- `32D` (Bra Size)
+- `32D (70D)` (Bra Size with Alternate Units)
+
+If the `Height` and `Weight` attributes are both present, they will be used to calculate the performer's body type.
 
 ### Tags
-The tags used will be generated or will use existing tags if there exists a tag with a matching name the tag names can be customized by changing the first parameter of the `StashTagDC` input in `body_tags.py`
-
+The tags will be generated or will use existing tags if there exists a tag with a matching name. The tag names can be customized by changing the first parameter of the `StashTagDC` input in `body_tags.py`

--- a/body_tags.py
+++ b/body_tags.py
@@ -145,8 +145,8 @@ class ButtSize(StashTagEnumComparable):
 def calculate_shape(performer):
 
     shapes = []
-    if performer.bust <= 0 and performer.waist <= 0 and performer.hips <= 0:
-        return
+    if not performer.bust or not performer.waist or not performer.hips:
+        return shapes
 
     bust_hips = performer.bust - performer.hips
     bust_waist = performer.bust - performer.waist

--- a/performer_body_calculator.py
+++ b/performer_body_calculator.py
@@ -223,7 +223,15 @@ class StashPerformer:
         if self.descriptor:
             descriptor = self.descriptor.name
         p_id = f"{self.name} ({self.id})"
-        return f"{p_id:>25} {self.bust:.0f}-{self.waist:.0f}-{self.hips:.0f} {self.bmi:5.2f} {descriptor:>7} {body_shapes:<17}"
+        p_str = f"{p_id:>25}"
+        if self.band and self.cupsize:
+            p_str += f" {self.band:.0f}{self.cupsize}"
+        elif self.bust:
+            p_str += f" {self.bust:.0f}"
+        if self.waist and self.hips:
+            p_str += f"-{self.waist:.0f}-{self.hips:.0f}"
+        p_str += f" {self.bmi:5.2f} {descriptor:>7} {body_shapes:<17}"
+        return p_str
     def __repr__(self) -> str:
         return str(self)
 


### PR DESCRIPTION
# New Measurement Formats

This change adds support for new measurement formats that are used by certain websites and scrapers. These formats have less data compared to the standard `{band}{cup}-{waist}-{hips}` format, so the plugin has been adapted to only calculate tags that it has relevant data for.

**Bust, Waist, Hips**
  - Example: `36-28-34`
  - Supports: Body Shape, Butt Size

![image](https://github.com/stg-annon/performerBodyCalculator/assets/149206247/2b5d6c8d-c515-4e3f-b623-80193afb3a32)

**Bra Size (with optional original units)**
  - Example: `32D` or `32D (70D)` or `32D(70D)`
  - Supports: Breast Size

![image](https://github.com/stg-annon/performerBodyCalculator/assets/149206247/e21daa21-3db0-4828-b42a-e17d00ff6557)

# Other

This change also makes measurements completely optional, allowing for BMI and Body Type to be calculated if measurements are not present, so performers with only height and weight specified will now be tagged.

![image](https://github.com/stg-annon/performerBodyCalculator/assets/149206247/a490f1e7-ee60-40ab-956e-fbe7157a63dc)

Additionally, because the plugin no longer only grabs models with defined measurements at the beginning, this resolves this issue where removing a performer's measurements would cause their tags to remain through future runs. Now the tags will be removed on the next run.

# Notes

- The readme has been updated significantly to reflect the new requirements. Please let me know if you'd like me to change anything!
- I did my best to keep the plugin's coding style, but if you don't like the way I did something, let me know and I'll change it 👍
- The fact that performers with no measurements are now pulled _could_ have performance/memory implications on **extremely** large performer databases... However, it still runs in less than a second on my low-powered server with 400 performers, so I really don't think it's a problem.